### PR TITLE
Shell version bump to 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "name": "Alt+Tab Scroll Workaround",
   "description": "Temporary fix for a bug that buffers the scroll between different windows (e.g., Chrome and VS Code).",
   "version": 1,
-  "shell-version": [ "42" ],
+  "shell-version": ["43"],
   "url": "https://github.com/lucasresck/gnome-shell-extension-alt-tab-scroll-workaround"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "name": "Alt+Tab Scroll Workaround",
   "description": "Temporary fix for a bug that buffers the scroll between different windows (e.g., Chrome and VS Code).",
   "version": 1,
-  "shell-version": ["43"],
+  "shell-version": ["42", "43"],
   "url": "https://github.com/lucasresck/gnome-shell-extension-alt-tab-scroll-workaround"
 }


### PR DESCRIPTION
Seems to be working fine on Ubuntu 22.10 without any changes.

This closes https://github.com/lucasresck/gnome-shell-extension-alt-tab-scroll-workaround/issues/5