### PR TITLE
Destroy all objects

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -97,5 +97,6 @@ export default class AltTabScrollWorkaroundExtension extends Extension {
     disable() {
         this._injectionManager.clear();
         this._injectionManager = null;
+        this.vdevice = null;
     }
 }

--- a/extension.js
+++ b/extension.js
@@ -40,12 +40,9 @@ function movePointer() {
 }
 
 export default class AltTabScrollWorkaroundExtension extends Extension {
-    constructor(metadata) {
-        super(metadata);
-        this._injectionManager = new InjectionManager();
-    }
-
     enable() {
+        this._injectionManager = new InjectionManager();
+
         // Fix for Alt+Tab (switch windows)
         this._injectionManager.overrideMethod(
             AltTab.WindowSwitcherPopup.prototype,

--- a/extension.js
+++ b/extension.js
@@ -43,8 +43,9 @@ export default class AltTabScrollWorkaroundExtension extends Extension {
             AltTab.WindowSwitcherPopup.prototype,
             "_finish",
             (originalMethod) => {
+                let that = this;
                 return function () {
-                    movePointer();
+                    that.movePointer();
                     originalMethod.call(this);
                 };
             }
@@ -55,9 +56,10 @@ export default class AltTabScrollWorkaroundExtension extends Extension {
             AltTab.AppSwitcherPopup.prototype,
             "_finish",
             (originalMethod) => {
+                let that = this;
                 return function (timestamp) {
                     if (this._currentWindow < 0) {
-                        movePointer();
+                        that.movePointer();
                     }
                     originalMethod.call(this, timestamp);
                 };
@@ -69,8 +71,9 @@ export default class AltTabScrollWorkaroundExtension extends Extension {
             AltTab.WindowCyclerPopup.prototype,
             "_finish",
             (originalMethod) => {
+                let that = this;
                 return function () {
-                    movePointer();
+                    that.movePointer();
                     originalMethod.call(this);
                 };
             }
@@ -81,8 +84,9 @@ export default class AltTabScrollWorkaroundExtension extends Extension {
             Overview.Overview.prototype,
             '_showDone',
             (originalMethod) => {
+                let that = this;
                 return function () {
-                    movePointer();
+                    that.movePointer();
                     originalMethod.call(this);
                 };
             }

--- a/extension.js
+++ b/extension.js
@@ -29,19 +29,14 @@ import * as AltTab from "resource:///org/gnome/shell/ui/altTab.js";
 
 import * as Overview from "resource:///org/gnome/shell/ui/overview.js";
 
-const seat = Clutter.get_default_backend().get_default_seat();
-const vdevice = seat.create_virtual_device(
-    Clutter.InputDeviceType.POINTER_DEVICE
-);
-
-function movePointer() {
-    const [x, y] = global.get_pointer();
-    vdevice.notify_absolute_motion(global.get_current_time(), x, y);
-}
 
 export default class AltTabScrollWorkaroundExtension extends Extension {
     enable() {
         this._injectionManager = new InjectionManager();
+        const seat = Clutter.get_default_backend().get_default_seat();
+        this.vdevice = seat.create_virtual_device(
+            Clutter.InputDeviceType.POINTER_DEVICE
+        );
 
         // Fix for Alt+Tab (switch windows)
         this._injectionManager.overrideMethod(
@@ -92,6 +87,11 @@ export default class AltTabScrollWorkaroundExtension extends Extension {
                 };
             }
         );
+    }
+
+    movePointer() {
+        const [x, y] = global.get_pointer();
+        this.vdevice.notify_absolute_motion(global.get_current_time(), x, y);
     }
 
     disable() {

--- a/extension.js
+++ b/extension.js
@@ -96,5 +96,6 @@ export default class AltTabScrollWorkaroundExtension extends Extension {
 
     disable() {
         this._injectionManager.clear();
+        this._injectionManager = null;
     }
 }


### PR DESCRIPTION
Fix https://github.com/lucasresck/gnome-shell-extension-alt-tab-scroll-workaround/issues/28.

Move outside class objects to inside class and null them out in `disable`.