### PR TITLE
Add GNOME 46 to the list of supported shell versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "name": "Alt+Tab Scroll Workaround",
   "description": "Quick fix to the bug where scrolling in one application is repeated in another when switching between them using Alt+Tab (e.g., VS Code and Chrome).",
   "version": 6,
-  "shell-version": ["45"],
+  "shell-version": ["45", "46"],
   "url": "https://github.com/lucasresck/gnome-shell-extension-alt-tab-scroll-workaround"
 }


### PR DESCRIPTION
Thanks for the extension; it seems to be working as expected on NixOS 24.05 with GNOME 46 without any changes.

#35