### PR TITLE
added GNOME 48 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/lucasresck/gnome-shell-extension-alt-tab-scroll-workaround"
 }


### PR DESCRIPTION
Since GNOME 48 was recently released, the extension stopped working.

I have confirmed that without the extension the bug still exists, that when switching among electron apps, the scrolling done on the previous window is weirdly applied again to the new window one switched to when scrolling there again.

I've done some testing locally and the extension code seems to work just fine on GNOME 48 without any changes aside from the version bump. I only tested some of the use cases though: switching applications with ALT+TAB and switching applications via the overview SUPER + clicking the new target window.

Wasn't sure if you'd like to bump the extension version itself as well with such changes or if you reserve the extension version to actual semantic changes.