### PR TITLE
bump gnome-shell version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,11 +2,12 @@
   "uuid": "alt-tab-scroll-workaround@lucasresck.github.io",
   "name": "Alt+Tab Scroll Workaround",
   "description": "Quick fix to the bug where scrolling in one application is repeated in another when switching between them using Alt+Tab (e.g., VS Code and Chrome).",
-  "version": 8,
+  "version": 9,
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/lucasresck/gnome-shell-extension-alt-tab-scroll-workaround"
 }


### PR DESCRIPTION
Extension works in GNOME 48.0 w/o any changes.

Tested on:
- OS: Arch Linux x86_64
- Linux kernel: 6.14.2-arch1-1
- DE: GNOME 48.0
- Apps tested: VSCode + Firefox/Discord